### PR TITLE
android: extract in a separated thread

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -24,6 +24,11 @@ apply plugin: 'com.android.library'
 android {
     compileSdkVersion 29
 
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
     defaultConfig {
         minSdkVersion 16
     }

--- a/android/src/main/java/com/syed/unrar_file/UnrarFilePlugin.java
+++ b/android/src/main/java/com/syed/unrar_file/UnrarFilePlugin.java
@@ -1,96 +1,85 @@
 package com.syed.unrar_file;
 
-import android.util.Log;
-
-import androidx.annotation.NonNull;
+import android.os.Handler;
+import android.os.Looper;
 
 import com.github.junrar.Junrar;
 import com.github.junrar.exception.RarException;
 import com.github.junrar.exception.UnsupportedRarV5Exception;
 
 import java.io.IOException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
 
+import androidx.annotation.NonNull;
 import io.flutter.embedding.engine.plugins.FlutterPlugin;
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugin.common.MethodChannel.Result;
-import io.flutter.plugin.common.PluginRegistry.Registrar;
-import java.util.concurrent.Executor;
-import java.util.concurrent.Executors;
-import android.os.Handler;
-import android.os.Looper;
 
-/** UnrarFilePlugin */
+/**
+ * UnrarFilePlugin
+ */
 public class UnrarFilePlugin implements FlutterPlugin, MethodCallHandler {
-  /// The MethodChannel that will the communication between Flutter and native Android
-  ///
-  /// This local reference serves to register the plugin with the Flutter Engine and unregister it
-  /// when the Flutter Engine is detached from the Activity
-  private MethodChannel channel;
-  private Executor executor = Executors.newCachedThreadPool();
-  Handler handler = new Handler(Looper.getMainLooper());
+    private final Executor executor = Executors.newCachedThreadPool();
+    Handler handler = new Handler(Looper.getMainLooper());
+    /// The MethodChannel that will the communication between Flutter and native Android
+    ///
+    /// This local reference serves to register the plugin with the Flutter Engine and unregister it
+    /// when the Flutter Engine is detached from the Activity
+    private MethodChannel channel;
 
-  public static boolean isNullOrEmpty(String str) {
-    if(str != null && !str.isEmpty())
-      return false;
-    return true;
-  }
-  @Override
-  public void onAttachedToEngine(@NonNull FlutterPluginBinding flutterPluginBinding) {
-    channel = new MethodChannel(flutterPluginBinding.getBinaryMessenger(), "unrar_file");
-    channel.setMethodCallHandler(this);
-  }
+    public static boolean isNullOrEmpty(String str) {
+        return str == null || str.isEmpty();
+    }
 
-  @Override
-  public void onMethodCall(@NonNull MethodCall call, @NonNull final Result result) {
-    if (call.method.equals("extractRAR")) {
-      final String file_path = call.argument("file_path");
-      final String destination_path = call.argument("destination_path");
-      final String password = call.argument("password");
-//      result.success("extraction done");
-        executor.execute(new Runnable() {
-            @Override
-            public void run() {
+    @Override
+    public void onAttachedToEngine(@NonNull FlutterPluginBinding flutterPluginBinding) {
+        channel = new MethodChannel(flutterPluginBinding.getBinaryMessenger(), "unrar_file");
+        channel.setMethodCallHandler(this);
+    }
+
+    @Override
+    public void onMethodCall(@NonNull MethodCall call, @NonNull final Result result) {
+        if (call.method.equals("extractRAR")) {
+            final String file_path = call.argument("file_path");
+            final String destination_path = call.argument("destination_path");
+            final String password = call.argument("password");
+            executor.execute(() -> {
                 try {
-                    if (isNullOrEmpty(password)) {
-                        Junrar.extract(file_path, destination_path);
-                    } else {
-                        Junrar.extract(file_path, destination_path, password);
-                    }
+                    extract(password, file_path, destination_path);
                     sendSuccess(result);
                 } catch (UnsupportedRarV5Exception e) {
-                    sendError(result, "extractionRAR5Error :: "+ e.toString());
+                    sendError(result, "extractionRAR5Error :: " + e);
                 } catch (IOException | RarException e) {
-                    sendError(result, "extractionError :: "+ e.toString());
+                    sendError(result, "extractionError :: " + e);
                 }
-            }
-        });
-    } else {
-      result.notImplemented();
+            });
+        } else {
+            result.notImplemented();
+        }
     }
-  }
+
+    private void extract(String password, String file_path, String destination_path)
+            throws RarException, IOException {
+        if (isNullOrEmpty(password)) {
+            Junrar.extract(file_path, destination_path);
+        } else {
+            Junrar.extract(file_path, destination_path, password);
+        }
+    }
 
     void sendSuccess(final Result result) {
-        handler.post(new Runnable() {
-            @Override
-            public void run() {
-                result.success("Extraction Success");
-            }
-        });
+        handler.post(() -> result.success("Extraction Success"));
     }
 
     void sendError(final Result result, final String msg) {
-        handler.post(new Runnable() {
-            @Override
-            public void run() {
-                result.error(msg, "", null);
-            }
-        });
+        handler.post(() -> result.error(msg, "", null));
     }
 
-  @Override
-  public void onDetachedFromEngine(@NonNull FlutterPluginBinding binding) {
-    channel.setMethodCallHandler(null);
-  }
+    @Override
+    public void onDetachedFromEngine(@NonNull FlutterPluginBinding binding) {
+        channel.setMethodCallHandler(null);
+    }
 }


### PR DESCRIPTION
Extract is freezing the UI, can not use a dart `compute` because it does not support native code. Fixed executing the extract inside an executor, and notifying the result in the main thread using a handler.

This branch can be added to dependencies directly until this PR is merged:
```
  unrar_file:
    git:
      url: https://github.com/ignaciotcrespo/unrar_file
      ref: android-async
```